### PR TITLE
Update Alpine version and disable Rust dependency as workaround to pyca/cryptography#5771

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.11
+FROM python:3.8-alpine3.13
 
 WORKDIR /srv
 
@@ -28,6 +28,10 @@ RUN apk add --update --no-cache \
     #make && \
     #make install && \
     #cd .. && rm -rf watchman
+
+# cryptography module incompatibility with PEP517
+# https://github.com/pyca/cryptography/issues/5771
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 # Install poetry
 RUN pip install poetry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3'
 
 services:
 


### PR DESCRIPTION
## Changes
- Update Python Alpine image version to `3.13` and disable Rust dependency that prevents cryptography from building.